### PR TITLE
fix: ERROR! [DEPRECATED]: ansible.builtin.include has been removed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
     msg: "Please provide the server_types"
   when: server_types is not defined
 
-- include: server_type.yml
+- include_tasks: server_type.yml
   with_items:  '{{ server_types }}'
   loop_control:
     loop_var: server_type


### PR DESCRIPTION
Update `include` to `include_tasks` to fix:
 
```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```